### PR TITLE
Callables can be surprising too

### DIFF
--- a/mutable_defaults.py
+++ b/mutable_defaults.py
@@ -6,6 +6,7 @@ __version__ = '1.0.5'
 
 
 mutable_types = [
+    ast.Call,
     ast.Dict,
     ast.List,
     ast.Set,

--- a/tests/mutable_defaults_test.py
+++ b/tests/mutable_defaults_test.py
@@ -19,6 +19,17 @@ from mutable_defaults import MutableDefaultChecker
         1
     ),
     ('def foo(bar=[], baz={}): pass', 2),
+    ('def foo(bar=range(10)): pass', 1),
+    ('def foo(bar=set()): pass', 1),
+    (
+        '\n'.join([
+            'def foo():',
+            '    return True',
+            'def bar(a=foo()):',
+            '    pass',
+        ]),
+        1
+    ),
     ('', 0),
 ], ids=(
     'dict',
@@ -27,6 +38,9 @@ from mutable_defaults import MutableDefaultChecker
     'valid_args_and_kwargs',
     'nested_function',
     'multiple_mutable_defaults',
+    'builtin_callable_with_value',
+    'builtin_callable_without_value',
+    'user_defined_callable',
     'empty_tree',
 ))
 def test_mutable_defaults(code, error_count):


### PR DESCRIPTION
Callables are also evaluated at function definition, which can also lead to surprising behavior.

Classic example would be thinking that you're getting an updated timestamp for free:

    In [3]: import datetime as dt

    In [4]: def log(timestamp=dt.datetime.utcnow()):
       ...:     print(timestamp)
       ...:

    In [5]: log()
    2016-11-18 20:00:36.537124

    In [6]: log()
    2016-11-18 20:00:36.537124

    In [7]: log()
    2016-11-18 20:00:36.537124

So let's warn on those too.