### PR TITLE
Modify entry point so errors are reported when flake8 runs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     ],
     entry_points={
         'flake8.extension': [
-            'M90 = mutable_defaults:MutableDefaultChecker',
+            'M5 = mutable_defaults:MutableDefaultChecker',
         ],
     },
     setup_requires=[


### PR DESCRIPTION
The entry point needs to start with the prefix of the error codes that will be raised, or flake8 won't report the results.