### PR TITLE
Add a framework classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
+        'Framework :: Flake8',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Warehouse (pypi.org) allows search results to be filtered by trove classifiers.
One such classifier is `Framework`, which accepts `Flake8` as a value. Setting
the classifier should help people find flake8-comprehensions when searching for
flake8 plugins.