### PR TITLE
Remove deprecated setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ setuptools.setup(
             'M90 = mutable_defaults:MutableDefaultChecker',
         ],
     },
-    setup_requires=[
-        'pytest-runner',
-    ],
     tests_require=[
         'pytest',
     ],


### PR DESCRIPTION
`pytest-runner` is used in a deprecated way: from `setup_requires`.

Most of the time this is not an issue, but sometimes it is: when installing the package using pip, `setup_requires` step tries to get `pytest-runner`. And that's the problem: the way `setup_requires` tries to get the missing package is not honoring pip configuration, such as different index, certificates, proxies, etc. 

Which means the installation of this package can fail in environments where pip needs to be correctly configured to use proxies for Internet access.

Additionally, [`pytest-runner` itself says that it is not recommended anymore](https://pypi.org/project/pytest-runner/):

> pytest-runner depends on deprecated features of setuptools and relies on features that break security mechanisms in pip. For example ‘setup_requires’ and
> ‘tests_require’ bypass pip --require-hashes. See also pypa/setuptools#1684.